### PR TITLE
Correct import path for base_interface.py

### DIFF
--- a/AlgoTuner/interfaces/core/base_interface.py
+++ b/AlgoTuner/interfaces/core/base_interface.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from AlgoTuner.config.model_config import GlobalConfig, GenericAPIModelConfig
 from AlgoTuner.utils.file_helpers import load_file_content
-from editor.editor_functions import Editor, EditorState, reload_all_llm_src
+from AlgoTuner.editor.editor_functions import Editor, EditorState, reload_all_llm_src
 from AlgoTuner.utils.message_writer import MessageWriter
 from AlgoTuner.utils.error_helpers import get_error_messages_cached
 from AlgoTuneTasks.base import Task


### PR DESCRIPTION
This PR addresses and resolves an incorrect import reference for the editor functionalities.

The import path for `Editor`, `EditorState`, and `reload_all_llm_src` has been updated from a relative path (`editor.editor_functions`) to the correct absolute path (`AlgoTuner.editor.editor_functions`). This change ensures proper module resolution and enhances the stability of the system.