### PR TITLE
Add custom pricing support for self-hosted models

### DIFF
--- a/AlgoTuner/config/config.yaml
+++ b/AlgoTuner/config/config.yaml
@@ -186,3 +186,14 @@ models:
     include_reasoning: true
     usage:
       include: true
+
+# --- Custom Pricing for Self-Hosted Models ---
+#   selfhosted/llama-3-70b:
+#     api_key_env: "SELFHOSTED_API_KEY"
+#     custom_pricing:
+#       litellm_provider: "openai"  # Provider name for LiteLLM pricing lookup
+#       mode: "chat"                 # Chat mode
+#       input_cost_per_token: 0.00005   # $0.05 per 1M tokens
+#       output_cost_per_token: 0.0001    # $0.10 per 1M tokens
+#       cache_creation_input_cost_per_token: 0.000025
+#       cache_read_input_cost_per_token: 0.00001


### PR DESCRIPTION
## Summary

This PR adds support for custom pricing configuration in AlgoTune, enabling users to specify custom pricing for self-hosted models or models with non-standard pricing through the OpenRouter API.

## Changes

### Implementation (`AlgoTuner/main.py`)
- Added `register_custom_pricing()` function that allows users to configure custom pricing
- The function checks for `custom_pricing` fields in model configuration
- Automatically applies default values (`litellm_provider`, `mode`) when not specified
- Registers pricing with LiteLLM before model info is retrieved to ensure accurate cost tracking

## Usage

Users can now configure custom pricing for self-hosted models in `config.yaml`:

```yaml
models:
  selfhosted/llama-3-70b:
    api_key_env: "SELFHOSTED_API_KEY"
    custom_pricing:
      litellm_provider: "openai"
      mode: "chat"
      input_cost_per_token: 0.00005   # $0.05 per 1M tokens
      output_cost_per_token: 0.0001    # $0.10 per 1M tokens
      cache_creation_input_cost_per_token: 0.000025
      cache_read_input_cost_per_token: 0.00001
```

## Supported Pricing Fields

Reference: [LiteLLM model_prices_and_context_window.json](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)

The `custom_pricing` field follows the same structure as LiteLLM's `model_prices_and_context_window.json` file. Users can reference this file for available pricing fields.

**Supported fields:**
- `litellm_provider` - The provider name (default: extracted from model name, e.g., "openai" from "openai/model")
- `mode` - The mode of operation (default: "chat"). Options: `chat`, `embedding`, `completion`, `image_generation`, `audio_transcription`, `audio_speech`, `image_generation`, `moderation`, `rerank`, `search`
- `input_cost_per_token` - Cost per input token in USD
- `output_cost_per_token` - Cost per output token in USD
- `cache_creation_input_token_cost` - Cost for cache creation (optional, matches LiteLLM field name)
- `cache_read_input_token_cost` - Cost for cache reads (optional, matches LiteLLM field name)
- `max_input_tokens` - Maximum input tokens (optional)
- `max_output_tokens` - Maximum output tokens (optional)
- `supports_function_calling` - Whether the model supports function calling (optional)
- `supports_reasoning` - Whether the model supports reasoning (optional)
- And more - see LiteLLM pricing file for complete list

**Example using LiteLLM pricing reference:**
```yaml
# Referencing OpenAI GPT-4 pricing from litellm model_prices_and_context_window.json
models:
  selfhosted/gpt-4-custom:
    api_key_env: "CUSTOM_API_KEY"
    custom_pricing:
      litellm_provider: "openai"
      mode: "chat"
      input_cost_per_token: 0.00003   # $0.03 per 1M tokens (GPT-4 input)
      output_cost_per_token: 0.00006   # $0.06 per 1M tokens (GPT-4 output)
      max_input_tokens: 8192
      max_output_tokens: 4096
```
